### PR TITLE
add handling for musicFolder

### DIFF
--- a/music-server-backend/subsonic_helpers.go
+++ b/music-server-backend/subsonic_helpers.go
@@ -89,6 +89,9 @@ func subsonicRespond(c *gin.Context, response SubsonicResponse) {
 			bodyMap["configurations"] = body
 		case *SubsonicLibraryPaths:
 			bodyMap["libraryPaths"] = body
+		case *SubsonicMusicFolders:
+			// Map to `musicFolder` to match Subsonic JSON expectations
+			bodyMap["musicFolder"] = body.Folders
 		case *OpenSubsonicExtensions:
 			bodyMap["openSubsonicExtensions"] = body.Extensions // Directly embed the slice
 		case *ApiKeyResponse:


### PR DESCRIPTION
Closes #6 

Adds handling for `MusicFolder` to json response.

`https://<host>/rest/getMusicFolders.view?apiKey=<redacted>&f=json` properly returns
```json
{"subsonic-response":{"musicFolder":[{"id":1,"name":"Music Library"}],"status":"ok","version":"1.16.1"}}
```